### PR TITLE
Fix dependencies

### DIFF
--- a/protonvpn_nm_lib/constants.py
+++ b/protonvpn_nm_lib/constants.py
@@ -12,7 +12,7 @@ from .enums import (KillswitchStatusEnum, NetshieldStatusEnum,
                     ProtocolImplementationEnum, SecureCoreStatusEnum,
                     UserSettingConnectionEnum, UserSettingStatusEnum)
 
-APP_VERSION = "3.3.2"
+from .version import APP_VERSION
 
 IPv6_LEAK_PROTECTION_CONN_NAME = "pvpn-ipv6leak-protection"
 IPv6_LEAK_PROTECTION_IFACE_NAME = "ipv6leakintrf0"

--- a/protonvpn_nm_lib/version.py
+++ b/protonvpn_nm_lib/version.py
@@ -1,0 +1,1 @@
+APP_VERSION = "3.3.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,1 @@
-# Call with pip install -r requirements.txt
-proton-client
-pyxdg
-keyring
-PyGObject
-Jinja2
-distro
+.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import find_packages, setup
 
-from protonvpn_nm_lib.constants import APP_VERSION
+from protonvpn_nm_lib.version import APP_VERSION
 
 long_description = """
 ProtonVPN NetworkManager library for Linux clients.
@@ -17,8 +17,13 @@ setup(
     author_email="contact@protonvpn.com",
     long_description=long_description,
     install_requires=[
-        "proton-client~=0.5.0", "pyxdg", "keyring",
-        "PyGObject", "Jinja2", "distro"
+        "dbus-python",
+        "distro",
+        "Jinja2",
+        "keyring",
+        "PyGObject",
+        "pyxdg",
+        "proton-client~=0.5.0",
     ],
     include_package_data=True,
     license="GPLv3",


### PR DESCRIPTION
dbus dependecy was missing

xdg was required to be installed because it was being imported from
constats.py, which is odd since `python setup.py install` should not
require any dependencies to be installed prior to run

make requirements.txt reflect the dependencies in setup.py

with this change install should work if using:

pip install -r requirements.txt

or

python3 setup.py install