### PR TITLE
:package: :arrow_up: rpmbuild: Follow Fedora Linux Packaging Guidelines

### DIFF
--- a/rpmbuild/SPECS/python3-protonvpn-nm-lib.spec
+++ b/rpmbuild/SPECS/python3-protonvpn-nm-lib.spec
@@ -1,23 +1,25 @@
 %define unmangled_name protonvpn-nm-lib
 %define version 3.6.1
-%define release 1
+%define release 2
 
 Prefix: %{_prefix}
 
 Name: python3-protonvpn-nm-lib
 Version: %{version}
-Release: %{release}
+Release: %{release}%{?dist}
 Summary: Official ProtonVPN NetworkManager library
 
 Group: ProtonVPN
 License: GPLv3
-Url: https://github.com/ProtonVPN/
 Vendor: Proton Technologies AG <opensource@proton.me>
-Source0: %{unmangled_name}-%{version}.tar.gz
+URL: https://github.com/ProtonVPN/%{unmangled_name}
+Source0: %{url}/archive/refs/tags/%{version}.tar.gz
 BuildArch: noarch
 BuildRoot: %{_tmppath}/%{unmangled_name}-%{version}-%{release}-buildroot
 
 BuildRequires: python3-devel
+BuildRequires: python3-pip
+BuildRequires: python3-pyxdg
 BuildRequires: python3-setuptools
 Requires: libsecret
 Requires: dbus-x11
@@ -51,8 +53,6 @@ python3 setup.py build
 %install
 python3 setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
 
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files -f INSTALLED_FILES
 %{python3_sitelib}/protonvpn_nm_lib/
@@ -60,6 +60,10 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 
 %changelog
+* Thu Nov 04 2021 Justin W. Flory <jflory7@fedoraproject.org> - 3.6.1-2
+- Improve: Greater conformity to Fedora Linux Packaging Guidelines for Python
+  https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/
+
 * Tue Nov 02 2021 Proton Technologies AG <opensource@proton.me> 3.6.1-1
 - Hotfix: Update event notifications
 
@@ -73,8 +77,8 @@ rm -rf $RPM_BUILD_ROOT
 - Fix: Wake on suspend has now an additional check to ensure that the reconnector kicks in only when the session is unlocked
 
 * Tue Jul 06 2021 Proton Technologies AG <opensource@proton.me> 3.4.1-3
-- More often update server maintenance status 
-- Feature: Alternative routing 
+- More often update server maintenance status
+- Feature: Alternative routing
 - Fix: Logs should be using UTC time
 - Fix: Add missing dependency
 


### PR DESCRIPTION
This commit makes changes to the RPM `.spec` file used to build and
create a binary RPM. The changes improve compatibility with the Fedora
Linux Packaging Guidelines for Python, although it does not meet full
compliance yet:

https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/

The changes made in this commit are as follows:

* Bump RPM release to 3.6.0-6
* Add `%{?dist}` macro to package version to add Fedora/EPEL identifier
  to package version string
* Change URL to Source0 to create a valid URL for fetching the release
  tarball from source
* Add missing `BuildRequires` for `python3-pip` and `python3-pyxdg`
* Fix rpmlint `superfluous-%clean-section` error for unnecessary
  clean-up step (see rpmlint output below)

```sh
rpmlint: 2.1.0
configuration:
    /usr/lib/python3.10/site-packages/rpmlint/configdefaults.toml
    /etc/xdg/rpmlint/fedora.toml
    /etc/xdg/rpmlint/licenses.toml
    /etc/xdg/rpmlint/scoring.toml
    /etc/xdg/rpmlint/users-groups.toml
    /etc/xdg/rpmlint/warn-on-functions.toml
checks: 31, packages: 1

python3-protonvpn-nm-lib.spec: E: superfluous-%clean-section
```

These changes were identified by running a local build with mock on the
`fedora-35-x86_64` configuration target. The source tarball was not
being downloaded and some Python library dependencies were missing at
build-time.