### PR TITLE
Fix ValueError: too many values to unpack

### DIFF
--- a/protonvpn_nm_lib/core/environment.py
+++ b/protonvpn_nm_lib/core/environment.py
@@ -145,6 +145,6 @@ class ExecutionEnvironment(metaclass=Singleton):
             import distro
             distribution, version, _ = distro.linux_distribution()
         except ImportError:
-            distribution, version = "Linux", "unknown distribution", "unknown version"
+            distribution, version, _ = "Linux", "unknown version", "unknown codename"
 
         return "ProtonVPN/{} (Linux; {}/{})".format(APP_VERSION, distribution, version)


### PR DESCRIPTION
We get an error trying to unpack 3 values onto 2 variables whenever we run it without `distro` installed.

This PR fixes it.