### PR TITLE
Added `dbus-python` to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ keyring
 PyGObject
 Jinja2
 distro
+dbus-python


### PR DESCRIPTION
I'm installing from source and noticed that python bindings for dbus are not listed in requirements.txt, which leads to the exception `protonvpn_nm_lib.exceptions.KeyringError: name 'dbus' is not defined` being raised.
Solution is to install such bindings (`pip install dbus-python`, or simply list `dbus-python` in requirements.txt)